### PR TITLE
Add feature of changing ownership of cert and key file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM docker:19.03.8
 LABEL maintainer="Humenius <contact@humenius.me>"
 
-ENV OVERRIDE_OWNER=FALSE \
-    OVERRIDE_UID=**None** \
-    OVERRIDE_GID=**None**
-
 RUN apk --no-cache add inotify-tools util-linux bash
 
 COPY run.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM docker:19.03.8
 LABEL maintainer="Humenius <contact@humenius.me>"
 
+ENV OVERRIDE_OWNER=FALSE \
+    OVERRIDE_UID=**None** \
+    OVERRIDE_GID=**None**
+
 RUN apk --no-cache add inotify-tools util-linux bash
 
 COPY run.sh /

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ services:
 ```
 
 ### Change ownership of certificate and key files
-If you want to change the onwership of the certificate and keyfile because your container runs on different permissions than root, you can specify the owner of the the owner PID en GID as an environment variable. These environment variables are `OVERRIDE_UID` and `OVERRIDE_GID`. These can only be integers and must both be set for the override to work. For instanse:
+If you want to change the onwership of the certificate and key files because your container runs on different permissions than `root`, you can specify the UID and GID as an environment variable. These environment variables are `OVERRIDE_UID` and `OVERRIDE_GID`. These can only be integers and must both be set for the override to work. For instance:
 ```yaml
 version: '3.7'
 

--- a/README.md
+++ b/README.md
@@ -47,5 +47,25 @@ services:
     - DOMAIN=example.org
 ```
 
+### Change ownership of certificate and key files
+If you want to change the onwership of the certificate and keyfile because your container runs on different permissions than root, you can specify the owner of the the owner PID en GID as an environment variable. These environment variables are `OVERRIDE_UID` and `OVERRIDE_GID`. These can only be integers and must both be set for the override to work. For instanse:
+```yaml
+version: '3.7'
+
+services:
+  certdumper:
+    image: humenius/traefik-certs-dumper:latest
+    container_name: traefik_certdumper
+    command: --restart-containers container1,container2,container3
+    volumes:
+    - ./traefik/acme:/traefik:ro
+    - ./output:/output:rw
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+    - DOMAIN=example.org
+    - OVERRIDE_UID=1000
+    - OVERRIDE_GID=1000
+```
+
 ## Help!
 If you need help using this image, have suggestions or want to report a problem, feel free to open an issue on GitHub!

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 WORKDIR=/tmp/work/
+re='^[0-9]+$'
 
 ###############################################
 ####             DUMPING LOGIC             ####
@@ -23,14 +24,20 @@ dump() {
     log "Certificate or key differ, updating"
     mv ${WORKDIR}/${DOMAIN}/*.pem /output/
 
+    #Check if OVERRIDE_UID and OVERRIDE_GID have been defined
     if [[ ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
-      if [[ "${OVERRIDE_UID}" =~ "^[0-9]+$" ]]; then
-        log "UID can only be intergers"
-      elif [[ "${OVERRIDE_GID}" =~ "^[0-9]+$" ]]; then
-        log "GID can only be integers"
+      if [[ "${OVERRIDE_UID}" =~ $re || "${OVERRIDE_GID}" =~ $re ]]; then
+          #Check on UID
+          if [[ "${OVERRIDE_UID}" =~ $re ]]; then
+              log "UID can only be intergers"
+          fi
+          #Check on GID
+          if [[ "${OVERRIDE_GID}" =~ $re ]]; then
+              log "GID can only be integers"
+          fi
       else
-        log "Changing ownership of Certificate and key"
-        chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
+          log "Changing ownership of Certificate and key"
+          chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
       fi
     fi
 

--- a/run.sh
+++ b/run.sh
@@ -24,22 +24,22 @@ dump() {
     log "Certificate or key differ, updating"
     mv ${WORKDIR}/${DOMAIN}/*.pem /output/
 
-  if [[ ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
-    if [[ ! "${OVERRIDE_UID}" =~ $re || ! "${OVERRIDE_GID}" =~ $re ]]; then
-        #Check on UID
-        if [[ ! "${OVERRIDE_UID}" =~ $re ]]; then
-            log "OVERRIDE_UID=${OVERRIDE_UID} is not an integer."
-        fi
-        #Check on GID
-        if [[ ! "${OVERRIDE_GID}" =~ $re ]]; then
-            log "OVERRIDE_GID=${OVERRIDE_GID} is not an integer."
-        fi
-        log "Combination ${OVERRIDE_UID}:${OVERRIDE_GID} is invalid. Skipping file ownership change..."
-    else
-        log "Changing ownership of Certificate and key"
-        chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
+    if [[ ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
+      if [[ ! "${OVERRIDE_UID}" =~ $re || ! "${OVERRIDE_GID}" =~ $re ]]; then
+          #Check on UID
+          if [[ ! "${OVERRIDE_UID}" =~ $re ]]; then
+              log "OVERRIDE_UID=${OVERRIDE_UID} is not an integer."
+          fi
+          #Check on GID
+          if [[ ! "${OVERRIDE_GID}" =~ $re ]]; then
+              log "OVERRIDE_GID=${OVERRIDE_GID} is not an integer."
+          fi
+          log "Combination ${OVERRIDE_UID}:${OVERRIDE_GID} is invalid. Skipping file ownership change..."
+      else
+          log "Changing ownership of certificate and key"
+          chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
+      fi
     fi
-  fi
 
     if [ ! -z "${CONTAINERS#}" ]; then
       log "Trying to restart containers"

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,11 @@ dump() {
     log "Certificate or key differ, updating"
     mv ${WORKDIR}/${DOMAIN}/*.pem /output/
 
+    if [[ "${OVERRIDE_OWNER}" == "TRUE" && ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
+      log "Changing ownership of Certificate and key"
+      chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem 
+    fi
+
     if [ ! -z "${CONTAINERS#}" ]; then
       log "Trying to restart containers"
       restart_containers

--- a/run.sh
+++ b/run.sh
@@ -36,8 +36,8 @@ dump() {
               log "GID can only be integers"
           fi
       else
-          log "Changing ownership of Certificate and key"
-          chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
+        log "Changing ownership of Certificate and key"
+        chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
       fi
     fi
 

--- a/run.sh
+++ b/run.sh
@@ -23,9 +23,15 @@ dump() {
     log "Certificate or key differ, updating"
     mv ${WORKDIR}/${DOMAIN}/*.pem /output/
 
-    if [[ "${OVERRIDE_OWNER}" == "TRUE" && ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
-      log "Changing ownership of Certificate and key"
-      chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem 
+    if [[ ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
+      if [[ "${OVERRIDE_UID}" =~ "^[0-9]+$" ]]; then
+        log "UID can only be intergers"
+      elif [[ "${OVERRIDE_GID}" =~ "^[0-9]+$" ]]; then
+        log "GID can only be integers"
+      else
+        log "Changing ownership of Certificate and key"
+        chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
+      fi
     fi
 
     if [ ! -z "${CONTAINERS#}" ]; then

--- a/run.sh
+++ b/run.sh
@@ -24,22 +24,22 @@ dump() {
     log "Certificate or key differ, updating"
     mv ${WORKDIR}/${DOMAIN}/*.pem /output/
 
-    #Check if OVERRIDE_UID and OVERRIDE_GID have been defined
-    if [[ ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
-      if [[ "${OVERRIDE_UID}" =~ $re || "${OVERRIDE_GID}" =~ $re ]]; then
-          #Check on UID
-          if [[ "${OVERRIDE_UID}" =~ $re ]]; then
-              log "UID can only be intergers"
-          fi
-          #Check on GID
-          if [[ "${OVERRIDE_GID}" =~ $re ]]; then
-              log "GID can only be integers"
-          fi
-      else
+  if [[ ! -z "${OVERRIDE_UID}" && ! -z "${OVERRIDE_GID}" ]]; then
+    if [[ ! "${OVERRIDE_UID}" =~ $re || ! "${OVERRIDE_GID}" =~ $re ]]; then
+        #Check on UID
+        if [[ ! "${OVERRIDE_UID}" =~ $re ]]; then
+            log "OVERRIDE_UID=${OVERRIDE_UID} is not an integer."
+        fi
+        #Check on GID
+        if [[ ! "${OVERRIDE_GID}" =~ $re ]]; then
+            log "OVERRIDE_GID=${OVERRIDE_GID} is not an integer."
+        fi
+        log "Combination ${OVERRIDE_UID}:${OVERRIDE_GID} is invalid. Skipping file ownership change..."
+    else
         log "Changing ownership of Certificate and key"
         chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" /output/*.pem
-      fi
     fi
+  fi
 
     if [ ! -z "${CONTAINERS#}" ]; then
       log "Trying to restart containers"


### PR DESCRIPTION
I added an option to change the ownership of the key file and the cert file.

I find that not all my docker-containers run as root. These containers are unable to load the key file because it's readonly for the user. 
Changing the owner when dumping fixes this issue for me.