### PR TITLE
Certificate dumping for multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,26 @@ services:
     - OVERRIDE_GID=1000
 ```
 
+### Extract multiple domains
+This Docker image is able to extract multiple domains as well. 
+Use environment variable `DOMAIN` and add you domains as a comma-separated list.
+After certificate dumping, the certificates can be found in the domains' subdirectories respectively.
+(`/output/DOMAIN[i]/...`)
+If you specify a single domain, the output folder remains the same as in previous versions (< v1.3 - `/output`).
+```yaml
+version: '3.7'
+
+services:
+  certdumper:
+    image: humenius/traefik-certs-dumper:latest
+    container_name: traefik_certdumper
+    volumes:
+    - ./traefik/acme:/traefik:ro
+    - ./output:/output:rw
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      DOMAIN: example.com,example.org,example.net,hello.example.in
+```
+
 ## Help!
 If you need help using this image, have suggestions or want to report a problem, feel free to open an issue on GitHub!

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-WORKDIR=/tmp/work/
+WORKDIR=/tmp/work
 re='^[0-9]+$'
 
 ###############################################
@@ -10,7 +10,7 @@ re='^[0-9]+$'
 
 dump() {
   log "Clearing dumping directory"
-  rm -rf $WORKDIR/*
+  rm -rf ${WORKDIR}/*
 
   log "Dumping certificates"
   traefik-certs-dumper file \
@@ -26,19 +26,19 @@ dump() {
   if [ "${#DOMAINS[@]}" -gt 1 ]; then
     for i in "${DOMAINS[@]}" ; do
       if
-        [[ -f /tmp/work/${i}/cert.pem && -f /tmp/work/${i}/key.pem && -f /output/${i}/cert.pem && -f /output/${i}/key.pem ]] && \
+        [[ -f ${WORKDIR}/${i}/cert.pem && -f ${WORKDIR}/${i}/key.pem && -f /output/${i}/cert.pem && -f /output/${i}/key.pem ]] && \
         diff -q ${WORKDIR}/${i}/cert.pem /output/{$i}/cert.pem >/dev/null && \
         diff -q ${WORKDIR}/${i}/key.pem /output/{$i}/key.pem >/dev/null
       then
         log "Certificate and key for '${i}' still up to date, doing nothing"
       else
         log "Certificate or key for '${i}' differ, updating"
-        mv ${WORKDIR}/${i}/*.pem /output/
+        mv ${WORKDIR}/${i}/*.pem /output/${i}
       fi
     done
   else
     if
-      [[ -f /tmp/work/${DOMAIN}/cert.pem && -f /tmp/work/${DOMAIN}/key.pem && -f /output/cert.pem && -f /output/key.pem ]] && \
+      [[ -f ${WORKDIR}/${DOMAIN}/cert.pem && -f ${WORKDIR}/${DOMAIN}/key.pem && -f /output/cert.pem && -f /output/key.pem ]] && \
       diff -q ${WORKDIR}/${DOMAIN}/cert.pem /output/cert.pem >/dev/null && \
       diff -q ${WORKDIR}/${DOMAIN}/key.pem /output/key.pem >/dev/null
     then

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 WORKDIR=/tmp/work/
 re='^[0-9]+$'
@@ -167,11 +168,6 @@ parse_commandline() {
   done
 }
 
-split_list() {
-  IFS=',' read -ra "$2" <<< "$1"
-  log "Values split! Got '${$2[@]}'"
-}
-
 ###############################################
 
 parse_commandline "$@"
@@ -180,14 +176,16 @@ if [ -z "${_arg_restart_containers}" ]; then
   log "--restart-containers is empty. Won't attempt to restart containers."
 else
   log "Got value of --restart-containers: ${_arg_restart_containers}. Splitting values."
-  split_list "${_arg_restart_containers}" CONTAINERS
+  IFS=',' read -ra CONTAINERS <<< "$_arg_restart_containers"
+  log "Values split! Got '${CONTAINERS[@]}'"
 fi
 
 if [ -z "${DOMAIN}" ]; then
-  die "Environment variable 'DOMAIN' mustn't be empty. Exiting..." 1
+  die "Environment variable DOMAIN mustn't be empty. Exiting..." 1
 else
-  log "Got value of 'DOMAIN': ${DOMAIN}. Splitting values."
-  split_list "${DOMAIN}" DOMAINS
+  log "Got value of DOMAIN: ${DOMAIN}. Splitting values."
+  IFS=',' read -ra DOMAINS <<< "$DOMAIN"
+  log "Values split! Got '${DOMAINS[@]}'"
 fi
 
 mkdir -p ${WORKDIR}

--- a/run.sh
+++ b/run.sh
@@ -23,12 +23,12 @@ dump() {
     --dest /tmp/work \
     --source /traefik/acme.json >/dev/null
 
-  if [ "${DOMAINS#}" -gt 1 ]; then
+  if [ "${#DOMAINS[@]}" -gt 1 ]; then
     for i in "${DOMAINS[@]}" ; do
       if
         [[ -f /tmp/work/${i}/cert.pem && -f /tmp/work/${i}/key.pem && -f /output/${i}/cert.pem && -f /output/${i}/key.pem ]] && \
-        diff -q ${WORKDIR}/${i}/cert.pem /output/cert.pem >/dev/null && \
-        diff -q ${WORKDIR}/${i}/key.pem /output/key.pem >/dev/null
+        diff -q ${WORKDIR}/${i}/cert.pem /output/{$i}/cert.pem >/dev/null && \
+        diff -q ${WORKDIR}/${i}/key.pem /output/{$i}/key.pem >/dev/null
       then
         log "Certificate and key for '${i}' still up to date, doing nothing"
       else
@@ -62,7 +62,7 @@ dump() {
       log "Combination ${OVERRIDE_UID}:${OVERRIDE_GID} is invalid. Skipping file ownership change..."
     else
       log "Changing ownership of certificates and keys"
-      find /output/ -type f -name "*.pem" | xargs -0 chown "${OVERRIDE_UID}":"${OVERRIDE_GID}"
+      find /output/ -type f -name "*.pem" -print0 | xargs chown "${OVERRIDE_UID}":"${OVERRIDE_GID}"
     fi
   fi
 


### PR DESCRIPTION
This feature allows users to use CSV syntax for domains. 
After being parsed, each domain's certificate and key will be dumped into a sub directory called by respective domain.
If a single domain is present, we dump it into the folder used in previous version (backward compatibility)