### PR TITLE
Fix unintended container exit on non-existing certificates

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -26,13 +26,11 @@ dump() {
   if [ "${#DOMAINS[@]}" -gt 1 ]; then
     for i in "${DOMAINS[@]}" ; do
       if
-        # 1. Check existence of file
         [[ -f ${workdir}/${i}/cert.pem && -f ${workdir}/${i}/key.pem && \
            -f ${outputdir}/${i}/cert.pem && -f ${outputdir}/${i}/key.pem ]]
       then
-        # 2. Check file diff
-        if diff -q ${workdir}/${i}/cert.pem ${outputdir}/{$i}/cert.pem >/dev/null && \
-           diff -q ${workdir}/${i}/key.pem ${outputdir}/{$i}/key.pem >/dev/null
+        if diff -q ${workdir}/$i/cert.pem ${outputdir}/$i/cert.pem >/dev/null && \
+           diff -q ${workdir}/$i/key.pem ${outputdir}/$i/key.pem >/dev/null
         then
           log "Certificate and key for '${i}' still up to date, doing nothing"
         else

--- a/run.sh
+++ b/run.sh
@@ -43,19 +43,19 @@ dump() {
     done
   else
     if
-      [[ -f ${workdir}/${DOMAIN}/cert.pem && -f ${workdir}/${DOMAIN}/key.pem && \
+      [[ -f ${workdir}/${DOMAINS[1]}/cert.pem && -f ${workdir}/${DOMAINS[1]}/key.pem && \
          -f ${outputdir}/cert.pem && -f ${outputdir}/key.pem ]]
     then
-      if diff -q ${workdir}/${DOMAIN}/cert.pem ${outputdir}/cert.pem >/dev/null && \
-         diff -q ${workdir}/${DOMAIN}/key.pem ${outputdir}/key.pem >/dev/null
+      if diff -q ${workdir}/${DOMAINS[1]}/cert.pem ${outputdir}/cert.pem >/dev/null && \
+         diff -q ${workdir}/${DOMAINS[1]}/key.pem ${outputdir}/key.pem >/dev/null
       then
-        log "Certificate and key for '${DOMAIN}' still up to date, doing nothing"
+        log "Certificate and key for '${DOMAINS[1]}' still up to date, doing nothing"
       else
-        log "Certificate or key for '${DOMAIN}' differ, updating"
-        mv ${workdir}/${DOMAIN}/*.pem ${outputdir}/
+        log "Certificate or key for '${DOMAINS[1]}' differ, updating"
+        mv ${workdir}/${DOMAINS[1]}/*.pem ${outputdir}/
       fi
     else
-      err "Certificates for domain '${i}' don't exist. Omitting..."
+      err "Certificates for domain '${DOMAINS[1]}' don't exist. Omitting..."
     fi
   fi
 

--- a/run.sh
+++ b/run.sh
@@ -26,16 +26,17 @@ dump() {
   if [ "${#DOMAINS[@]}" -gt 1 ]; then
     for i in "${DOMAINS[@]}" ; do
       if
-        [[ -f ${workdir}/${i}/cert.pem && -f ${workdir}/${i}/key.pem && \
-           -f ${outputdir}/${i}/cert.pem && -f ${outputdir}/${i}/key.pem ]]
+        [[ -f ${workdir}/${i}/cert.pem && -f ${workdir}/${i}/key.pem ]]
       then
-        if diff -q ${workdir}/$i/cert.pem ${outputdir}/$i/cert.pem >/dev/null && \
+        if [[ -f ${outputdir}/${i}/cert.pem && -f ${outputdir}/${i}/key.pem ]] && \
+           diff -q ${workdir}/$i/cert.pem ${outputdir}/$i/cert.pem >/dev/null && \
            diff -q ${workdir}/$i/key.pem ${outputdir}/$i/key.pem >/dev/null
         then
           log "Certificate and key for '${i}' still up to date, doing nothing"
         else
           log "Certificate or key for '${i}' differ, updating"
-          mv ${workdir}/${i}/*.pem ${dir}/
+          local dir=${outputdir}/${i}
+          mkdir -p ${dir} && mv ${workdir}/${i}/*.pem ${dir}
         fi
       else
         err "Certificates for domain '${i}' don't exist. Omitting..."
@@ -43,19 +44,19 @@ dump() {
     done
   else
     if
-      [[ -f ${workdir}/${DOMAINS[1]}/cert.pem && -f ${workdir}/${DOMAINS[1]}/key.pem && \
-         -f ${outputdir}/cert.pem && -f ${outputdir}/key.pem ]]
+      [[ -f ${workdir}/${DOMAINS[0]}/cert.pem && -f ${workdir}/${DOMAINS[0]}/key.pem ]]
     then
-      if diff -q ${workdir}/${DOMAINS[1]}/cert.pem ${outputdir}/cert.pem >/dev/null && \
-         diff -q ${workdir}/${DOMAINS[1]}/key.pem ${outputdir}/key.pem >/dev/null
+      if [[ -f ${outputdir}/cert.pem && -f ${outputdir}/key.pem ]] && \
+         diff -q ${workdir}/${DOMAINS[0]}/cert.pem ${outputdir}/cert.pem >/dev/null && \
+         diff -q ${workdir}/${DOMAINS[0]}/key.pem ${outputdir}/key.pem >/dev/null
       then
-        log "Certificate and key for '${DOMAINS[1]}' still up to date, doing nothing"
+        log "Certificate and key for '${DOMAINS[0]}' still up to date, doing nothing"
       else
-        log "Certificate or key for '${DOMAINS[1]}' differ, updating"
-        mv ${workdir}/${DOMAINS[1]}/*.pem ${outputdir}/
+        log "Certificate or key for '${DOMAINS[0]}' differ, updating"
+        mv ${workdir}/${DOMAINS[0]}/*.pem ${outputdir}/
       fi
     else
-      err "Certificates for domain '${DOMAINS[1]}' don't exist. Omitting..."
+      err "Certificates for domain '${DOMAINS[0]}' don't exist. Omitting..."
     fi
   fi
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 workdir=/tmp/work
 outputdir=/output
@@ -37,7 +36,11 @@ dump() {
         local dir=${outputdir}/${i}
         [ -a "$dir" ] || \
         mkdir -p $dir && \
-        mv ${workdir}/${i}/*.pem $dir
+        mv ${workdir}/${i}/*.pem ${dir}/
+
+        if [ ! $? -eq 0 ]; then
+          err "Could not move certificates for domain '${i}' to output folder. Certificates probably may not exist."
+        fi
       fi
     done
   else
@@ -50,6 +53,11 @@ dump() {
     else
       log "Certificate or key for '${DOMAIN}' differ, updating"
       mv ${workdir}/${DOMAIN}/*.pem ${outputdir}/
+
+      if [ ! $? -eq 0 ]; then
+        err "Could not move certificates for domain '${DOMAIN}' to output folder. Certificates probably may not exist."
+        return 1
+      fi
     fi
   fi
 

--- a/run.sh
+++ b/run.sh
@@ -26,38 +26,38 @@ dump() {
   if [ "${#DOMAINS[@]}" -gt 1 ]; then
     for i in "${DOMAINS[@]}" ; do
       if
-        [[ -f ${workdir}/${i}/cert.pem && -f ${workdir}/${i}/key.pem && -f ${outputdir}/${i}/cert.pem && -f ${outputdir}/${i}/key.pem ]] && \
-        diff -q ${workdir}/${i}/cert.pem ${outputdir}/{$i}/cert.pem >/dev/null && \
-        diff -q ${workdir}/${i}/key.pem ${outputdir}/{$i}/key.pem >/dev/null
+        # 1. Check existence of file
+        [[ -f ${workdir}/${i}/cert.pem && -f ${workdir}/${i}/key.pem && \
+           -f ${outputdir}/${i}/cert.pem && -f ${outputdir}/${i}/key.pem ]]
       then
-        log "Certificate and key for '${i}' still up to date, doing nothing"
-      else
-        log "Certificate or key for '${i}' differ, updating"
-        local dir=${outputdir}/${i}
-        [ -a "$dir" ] || \
-        mkdir -p $dir && \
-        mv ${workdir}/${i}/*.pem ${dir}/
-
-        if [ ! $? -eq 0 ]; then
-          err "Could not move certificates for domain '${i}' to output folder. Certificates probably may not exist."
+        # 2. Check file diff
+        if diff -q ${workdir}/${i}/cert.pem ${outputdir}/{$i}/cert.pem >/dev/null && \
+           diff -q ${workdir}/${i}/key.pem ${outputdir}/{$i}/key.pem >/dev/null
+        then
+          log "Certificate and key for '${i}' still up to date, doing nothing"
+        else
+          log "Certificate or key for '${i}' differ, updating"
+          mv ${workdir}/${i}/*.pem ${dir}/
         fi
+      else
+        err "Certificates for domain '${i}' don't exist. Omitting..."
       fi
     done
   else
     if
-      [[ -f ${workdir}/${DOMAIN}/cert.pem && -f ${workdir}/${DOMAIN}/key.pem && -f ${outputdir}/cert.pem && -f ${outputdir}/key.pem ]] && \
-      diff -q ${workdir}/${DOMAIN}/cert.pem ${outputdir}/cert.pem >/dev/null && \
-      diff -q ${workdir}/${DOMAIN}/key.pem ${outputdir}/key.pem >/dev/null
+      [[ -f ${workdir}/${DOMAIN}/cert.pem && -f ${workdir}/${DOMAIN}/key.pem && \
+         -f ${outputdir}/cert.pem && -f ${outputdir}/key.pem ]]
     then
-      log "Certificate and key for '${DOMAIN}' still up to date, doing nothing"
-    else
-      log "Certificate or key for '${DOMAIN}' differ, updating"
-      mv ${workdir}/${DOMAIN}/*.pem ${outputdir}/
-
-      if [ ! $? -eq 0 ]; then
-        err "Could not move certificates for domain '${DOMAIN}' to output folder. Certificates probably may not exist."
-        return 1
+      if diff -q ${workdir}/${DOMAIN}/cert.pem ${outputdir}/cert.pem >/dev/null && \
+         diff -q ${workdir}/${DOMAIN}/key.pem ${outputdir}/key.pem >/dev/null
+      then
+        log "Certificate and key for '${DOMAIN}' still up to date, doing nothing"
+      else
+        log "Certificate or key for '${DOMAIN}' differ, updating"
+        mv ${workdir}/${DOMAIN}/*.pem ${outputdir}/
       fi
+    else
+      err "Certificates for domain '${i}' don't exist. Omitting..."
     fi
   fi
 


### PR DESCRIPTION
See #5. I tried out to leave `set -e` for fail fast, but in the end, it leads to an unintended container exit. It's caused by moving certificates for domains where
- the domain does not exist or
- the certificates are not present.