### PR TITLE
Ownership, permissions and container restart fix

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -73,7 +73,9 @@ dump() {
       log "Combination ${OVERRIDE_UID}:${OVERRIDE_GID} is invalid. Skipping file ownership change..."
     else
       log "Changing ownership of certificates and keys"
-      find ${outputdir}/ -type f -name "*.pem" -print0 | xargs chown "${OVERRIDE_UID}":"${OVERRIDE_GID}"
+      find ${outputdir}/ -type f -name "*.pem" | while read f ;do 
+        chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" "$f"
+      done
     fi
   fi
 

--- a/run.sh
+++ b/run.sh
@@ -75,6 +75,7 @@ dump() {
       log "Changing ownership of certificates and keys"
       find ${outputdir}/ -type f -name "*.pem" | while read f ;do 
         chown "${OVERRIDE_UID}":"${OVERRIDE_GID}" "$f"
+        chmod g+r "$f"
       done
     fi
   fi


### PR DESCRIPTION
I'm submitting these three commits for review.

1. Fix UID/GID changes only being applied to the first file encountered.
2. Give read permissions to OVERRIDE_GID for all files.
3. Fix containers being restarted on every run.