### PR TITLE
Add support for arm64/armhf builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM docker:19.03.8
+FROM ldez/traefik-certs-dumper:v2.7.0
+
 LABEL maintainer="Humenius <contact@humenius.me>"
 
-RUN apk --no-cache add inotify-tools util-linux bash
+RUN \
+    apk update && \
+    apk add --no-cache \
+        inotify-tools \
+        util-linux \
+        bash
 
 COPY run.sh /
 
 RUN ["chmod", "+x", "/run.sh"]
-
-COPY --from=ldez/traefik-certs-dumper:v2.7.0 /usr/bin/traefik-certs-dumper /usr/bin/traefik-certs-dumper
 
 VOLUME ["/traefik"]
 VOLUME ["/output"]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,21 @@
+FROM ldez/traefik-certs-dumper:v2.7.0-arm.v8
+
+LABEL maintainer="Humenius <contact@humenius.me>"
+
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+RUN \
+    apk update && \
+    apk add --no-cache \
+        inotify-tools \
+        util-linux \
+        bash
+
+COPY run.sh /
+
+RUN ["chmod", "+x", "/run.sh"]
+
+VOLUME ["/traefik"]
+VOLUME ["/output"]
+
+ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,21 @@
+FROM ldez/traefik-certs-dumper:v2.7.0-arm.v7
+
+LABEL maintainer="Humenius <contact@humenius.me>"
+
+COPY --from=multiarch/qemu-user-static:x86_64-arm /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+RUN \
+    apk update && \
+    apk add --no-cache \
+        inotify-tools \
+        util-linux \
+        bash
+
+COPY run.sh /
+
+RUN ["chmod", "+x", "/run.sh"]
+
+VOLUME ["/traefik"]
+VOLUME ["/output"]
+
+ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
This change adds support for multi-arch images (arm64/armhf) which includes devices like a Raspberry Pi. I've also changed the base build image to `ldez/traefik-certs-dumper` instead of `docker` which simplifies the image and makes it smaller.