### PR TITLE
Fix container with same name start

### DIFF
--- a/bin/dump
+++ b/bin/dump
@@ -94,7 +94,7 @@ restart_containers() {
     for i in "${CONTAINERS[@]}"; do
       log "Looking up container with name ${i}"
 
-      local found_container=$(docker ps -qaf name="${i}")
+      local found_container=$(docker container inspect -f {{.Id}} "${i}" || echo "")
       if [ ! -z "${found_container}" ]; then
         log "Found '${found_container}'. Restarting now..."
 


### PR DESCRIPTION
The current command docker ps with filter by name might return multiple
containers. See docs:
> The name filter matches on all or part of a container’s name
> https://docs.docker.com/engine/reference/commandline/ps/#name

The proposed method uses container inspect with a fallback to ignore
the return code 1 and formats to only return the Id