### PR TITLE
Fix bash syntax errors

### DIFF
--- a/bin/dump
+++ b/bin/dump
@@ -89,7 +89,7 @@ change_ownership() {
 }
 
 restart_containers() {
-  if [ ! -z "${CONTAINERS#}" && "${_docker_available}" = true ]; then
+  if [[ ! -z "${CONTAINERS#}" && "${_docker_available}" = true ]]; then
     log "Trying to restart containers"
     
     for i in "${CONTAINERS[@]}"; do
@@ -119,7 +119,7 @@ restart_containers() {
 }
 
 restart_services() {
-  if [ ! -z "${SERVICES#}" && "${_docker_available}" = true ]; then
+  if [[ ! -z "${SERVICES#}" && "${_docker_available}" = true ]]; then
     log "Trying to restart services"
     
     for i in "${SERVICES[@]}"; do


### PR DESCRIPTION
When I created a new docker image from the develop branch (in order to get the restart-services option, which is not on Docker Hub yet), I got the following errors when running the container
```
traefik_certdumper | /usr/bin/dump: line 92: [: missing `]'
traefik_certdumper | /usr/bin/dump: line 122: [: missing `]'
```
This PR fixes these syntax errors.